### PR TITLE
Exit code 0 even if sudo password is not provided

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ readonly GREEN="$(tput setaf 2 2>/dev/null || echo '')"
 readonly CYAN="$(tput setaf 6 2>/dev/null || echo '')"
 readonly NO_COLOR="$(tput sgr0 2>/dev/null || echo '')"
 
+set -e
+
 # Define the release information
 RELEASE_URL="https://api.github.com/repos/pocketenv-io/pocketenv/releases/latest"
 


### PR DESCRIPTION
## Issue
When installing using `install.sh`, if I don't provide password when moving the executable to the installation directory,
```bash
...
    if command -v sudo >/dev/null 2>&1; then
        sudo mv /tmp/pocketenv $INSTALL_DIR
...
```
, the script will continue, will print
```
Installation completed! 🎉
To get started, run:
pocketenv init
```

and will exit with status code 0, even if the executable will still be at `/tmp/pocketenv` and not at `/usr/local/bin`.

## Solution
This PR adds the line `set -e` to solve this issue.